### PR TITLE
update to reflect the "latest unofficial" protocol

### DIFF
--- a/example.js
+++ b/example.js
@@ -1,6 +1,7 @@
 var
   MyQ = require('liftmaster'),
-  garageDoor = new MyQ('chad@developer.email', 'correct horse battery staple'),
+  util = require('util'),
+  garageDoor = new MyQ('username', 'password'),
   doorStates = {
     '1': 'open',
     '2': 'closed',
@@ -8,30 +9,29 @@ var
     '5': 'closing'
   };
 
+
 // log in to MyQ
-garageDoor.login(function(err, res) {
-  if(err) throw err;
+garageDoor.login(function(err) {
+  if(!!err) return console.log(err);
 
   // get all garage door devices
   garageDoor.getDevices(function(err, devices) {
-    if(err) throw err;
+    if(!!err) return console.log(err);
+
+    console.log(util.inspect(devices, { depth: null }));
 
     // log each door state
     devices.forEach(function(device) {
-      console.log(device.name, doorStates[device.state]);
-    });
+      console.log(util.inspect(device, { depth: null }));
+      console.log('    doorState=' + doorStates[device.state]);
 
-    // get the status of a single door
-    var device = devices[0];
-    garageDoor.getDoorState(device.id, function(err, device) {
-      if(err) throw err;
-      console.log(device);
-    });
+      garageDoor.getDoorState(device.id, function(err, door) {
+        console.log('>>> getDoorState ' + device.id + ' !!err=' + (!!err) + ' !!door=' + (!!door));
+        if(!!err) return console.log(err);
 
-    // open that door
-    garageDoor.setDoorState(device.id, 1, function(err, device) {
-      if(err) throw err;
-      console.log(device);
+        console.log(util.inspect(door, { depth: null }));
+        console.log('    state=' + doorStates[door.state]);
+      });
     });
   });
 });

--- a/example.js
+++ b/example.js
@@ -26,7 +26,6 @@ garageDoor.login(function(err) {
       console.log('    doorState=' + doorStates[device.state]);
 
       garageDoor.getDoorState(device.id, function(err, door) {
-        console.log('>>> getDoorState ' + device.id + ' !!err=' + (!!err) + ' !!door=' + (!!door));
         if(!!err) return console.log(err);
 
         console.log(util.inspect(door, { depth: null }));

--- a/liftmaster.js
+++ b/liftmaster.js
@@ -2,73 +2,135 @@ var request = require('request');
 
 var MyQ = module.exports = function(username, password) {
   this.endpoint = 'https://myqexternal.myqdevice.com';
-  this.appId = 'Vj8pQggXLhLy0WHahglCD4N1nAkkXQtGYpq2HrHD7H1nvmbT55KqtN6RSF4ILB/i';
+  this.appId = 'NWknvuBd7LoFHfXmKNMBcgajXtZEgKUh4V7WNzMidrpUUluDpVYVZx+xT4PCM5Kx';
   this.username = username;
   this.password = password;
+  this.brandID = 'Chamberlain';
+  this.expiration = 0;
 };
 
 MyQ.prototype.login = function(callback) {
   var _self = this;
   request({
     method: 'GET',
-    uri: _self.endpoint + '/Membership/ValidateUserWithCulture',
+    uri: _self.endpoint + '/api/user/validatewithculture',
+    headers: {
+      'User-Agent': _self.brandID + '/1332 (iPhone; iOS 7.1.1; Scale/2.00)'
+    },
     qs: {
       appId: _self.appId,
-      securityToken: null,
       username: _self.username,
       password: _self.password,
-      culture: 'en'
+      culture: 'en',
+      filterOn: true
     },
     json: true
   }, function(err, res, body) {
-    if(err || body.ErrorMessage)
-      return callback(err || new Error(body.ErrorMessage));
+    if(err || body.Message || body.ErrorMessage)
+      return callback(err || new Error(body.Message || body.ErrorMessage));
+
     _self.userId = body.UserId;
     _self.securityToken = body.SecurityToken;
-    return callback(null, body);
+    _self.brandID = body.BrandName;
+    _self.expiration = new Date().getTime() + (5 * 60 * 1000);
+
+    callback(null, body);
   });
 };
 
 MyQ.prototype.getDevices = function(callback) {
   var _self = this;
+
+  if(!_self.securityToken) callback(new Error('not logged in'));
+  if(_self.expiration <= new Date().getTime()) {
+    return _self.login(function(err) {
+      if(!!err) return callback(err);
+
+      _self.getDevices(callback);
+    });
+  }
+
   request({
     method: 'GET',
-    uri: _self.endpoint + '/api/UserDeviceDetails',
+    uri: _self.endpoint + '/api/userdevicedetails/get',
+    headers: {
+      'User-Agent': _self.brandID + '/1332 (iPhone; iOS 7.1.1; Scale/2.00)'
+    },
     qs: {
       appId: _self.appId,
       securityToken: _self.securityToken,
-      filterOn: true
     },
     json: true
   }, function(err, res, body) {
-    if(err || body.ErrorMessage)
-      return callback(err || new Error(body.ErrorMessage));
+    if(err || body.Message || body.ErrorMessage)
+      return callback(err || new Error(body.Message || body.ErrorMessage));
+
+    _self.gateways = [];
+    _self.children = {};
+    body.Devices.forEach(function(Device) {
+      if(Device.TypeId != 49) return;
+
+      var gateway = {
+        id: Device.DeviceId, type: 'gateway', serialNo: Device.SerialNumber, name: Device.DeviceName, devices: []
+      };
+      var response;
+      Device.Attributes.forEach(function(attribute) {
+        if(attribute.Name === 'desc') gateway.name = attribute.Value;
+        else if(attribute.Name === 'devices') gateway.devices = attribute.Value.split(',');
+        else if(attribute.Name === 'deviceRecord.response') response = attribute.Value;
+      });
+      _self.gateways.push(gateway);
+      gateway.devices.forEach(function(deviceId) {
+        if ((!!response) && (response.indexOf(deviceId) === -1)) return;
+
+        _self.children[deviceId] = { location: gateway.name };
+      });
+    });
+
     _self.devices = [];
-    body.Devices.forEach(function(Device, device) {
-      if(Device.MyQDeviceTypeId != 2)
-        return;
-      device = {
-        id: Device.DeviceId
+    body.Devices.forEach(function(Device) {
+      if((Device.TypeId != 47) && (Device.TypeId != 259)) return;
+      if(!_self.children[Device.DeviceId]) return;
+      Device.Location = _self.children[Device.DeviceId].location;
+      _self.children[Device.DeviceId] = Device;
+
+      var device = {
+        id: Device.DeviceId, type: 'garageDoor', serialNo: Device.DeviceName, name: 'Garage Door Opener',
+        location: Device.Location
       };
       Device.Attributes.forEach(function(attribute) {
-        if(attribute.Name == 'desc')
+        if(attribute.Name === 'desc')
           device.name = attribute.Value;
-        if(attribute.Name == 'doorstate') {
+        if(attribute.Name === 'doorstate') {
           device.state = attribute.Value;
           device.updated = attribute.UpdatedTime;
         }
       });
       _self.devices.push(device);
     });
-    return callback(null, _self.devices);
+
+    callback(null, _self.devices);
   });
 };
 
 MyQ.prototype.getDoorState = function(deviceId, callback) {
   var _self = this;
+
+  if(!_self.securityToken) callback(new Error('not logged in'));
+  if(_self.expiration <= new Date().getTime()) {
+    return _self.login(function(err) {
+      if(!!err) return callback(err);
+
+      _self.getDoorState(deviceId, callback);
+    });
+  }
+
   request({
     method: 'GET',
-    uri: _self.endpoint + '/Device/getDeviceAttribute',
+    uri: _self.endpoint + '/api/deviceattribute/getdeviceattribute',
+    headers: {
+      'User-Agent': _self.brandID + '/1332 (iPhone; iOS 7.1.1; Scale/2.00)'
+    },
     qs: {
       appId: _self.appId,
       securityToken: _self.securityToken,
@@ -77,13 +139,14 @@ MyQ.prototype.getDoorState = function(deviceId, callback) {
     },
     json: true
   }, function(err, res, body) {
-    if(err || body.ErrorMessage)
-      return callback(err || new Error(body.ErrorMessage));
+    if(err || body.Message || body.ErrorMessage)
+      return callback(err || new Error(body.Message || body.ErrorMessage));
+
     _self.devices.forEach(function(device) {
       if(device.id == deviceId) {
         device.state = body.AttributeValue;
         device.updated = body.UpdatedTime;
-        return callback(null, device); 
+        callback(null, device);
       }
     });
   });
@@ -91,20 +154,30 @@ MyQ.prototype.getDoorState = function(deviceId, callback) {
 
 MyQ.prototype.setDoorState = function(deviceId, state, callback) {
   var _self = this;
+
+  if(!_self.securityToken) callback(new Error('not logged in'));
+  if(_self.expiration <= new Date().getTime()) {
+    return _self.login(function(err) {
+      if(!!err) return callback(err);
+
+      _self.setDoorState(deviceId, state, callback);
+    });
+  }
+
   request({
     method: 'PUT',
-    uri: _self.endpoint + '/Device/setDeviceAttribute',
+    uri: _self.endpoint + '/api/deviceattribute/putdeviceattribute',
     body: {
       DeviceId: deviceId,
-      ApplicationId: _self.appId,
       AttributeName: 'desireddoorstate',
       AttributeValue: state,
       securityToken: _self.securityToken
     },
     json: true
   }, function(err, res, body) {
-    if(err || body.ErrorMessage)
-      return callback(err || new Error(body.ErrorMessage));
+    if(err || body.Message || body.ErrorMessage)
+      return callback(err || new Error(body.Message || body.ErrorMessage));
+
     setTimeout(function() {
       _self._loopDoorState(deviceId, callback);
     }, 1000);
@@ -113,14 +186,16 @@ MyQ.prototype.setDoorState = function(deviceId, state, callback) {
 
 MyQ.prototype._loopDoorState = function(deviceId, callback) {
   var _self = this;
+
+
   _self.getDoorState(deviceId, function(err, res) {
     if(err)
       return callback(err);
-    if(res.state == 4 || res.state == 5)
-      setTimeout(function() {
-        _self._loopDoorState(deviceId, callback)
-      }, 5000);
-    else
-      return callback(null, res);
+
+    if((res.state !== 4) && (res.state !== 5)) return callback(null, res);
+
+    setTimeout(function() {
+      _self._loopDoorState(deviceId, callback);
+    }, 5000);
   });
 };

--- a/liftmaster.js
+++ b/liftmaster.js
@@ -76,11 +76,13 @@ MyQ.prototype.getDevices = function(callback) {
         id: Device.DeviceId, type: 'gateway', serialNo: Device.SerialNumber, name: Device.DeviceName, devices: []
       };
       var response;
-      Device.Attributes.forEach(function(attribute) {
-        if(attribute.Name === 'desc') gateway.name = attribute.Value;
-        else if(attribute.Name === 'devices') gateway.devices = attribute.Value.split(',');
-        else if(attribute.Name === 'deviceRecord.response') response = attribute.Value;
-      });
+      if (!!Device.Attributes) {
+        Device.Attributes.forEach(function(attribute) {
+          if(attribute.Name === 'desc') gateway.name = attribute.Value;
+          else if(attribute.Name === 'devices') gateway.devices = attribute.Value.split(',');
+          else if(attribute.Name === 'deviceRecord.response') response = attribute.Value;
+        });
+      }
       _self.gateways.push(gateway);
       gateway.devices.forEach(function(deviceId) {
         if ((!!response) && (response.indexOf(deviceId) !== -1)) return;

--- a/liftmaster.js
+++ b/liftmaster.js
@@ -165,7 +165,7 @@ MyQ.prototype.setDoorState = function(deviceId, openP, callback, fastP) {
     return _self.login(function(err) {
       if(!!err) return callback(err);
 
-      _self.setDoorState(deviceId, state, callback);
+      _self.setDoorState(deviceId, openP, callback, fastP);
     });
   }
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "name": "liftmaster",
   "description": "Control your LiftMaster MyQ garage door openers",
   "keywords": ["liftmaster", "myq", "garage door"],
-  "version": "0.1.0",
+  "version": "0.1.1",
   "homepage": "https://github.com/chadsmith/node-liftmaster",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "name": "liftmaster",
   "description": "Control your LiftMaster MyQ garage door openers",
   "keywords": ["liftmaster", "myq", "garage door"],
-  "version": "0.0.1",
+  "version": "0.1.0",
   "homepage": "https://github.com/chadsmith/node-liftmaster",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "name": "liftmaster",
   "description": "Control your LiftMaster MyQ garage door openers",
   "keywords": ["liftmaster", "myq", "garage door"],
-  "version": "0.1.1",
+  "version": "0.1.2",
   "homepage": "https://github.com/chadsmith/node-liftmaster",
   "repository": {
     "type": "git",

--- a/readme.md
+++ b/readme.md
@@ -43,13 +43,15 @@ Retrieves the latest state of the requested door.
         console.log(device);
       });
 
-### garageDoor.setDoorState(id, state, callback)
-
-Set the requested door to open or close. Returns an updated state once complete.
-
 Known door states: 1 = open, 2 = closed, 4 = opening, 5 = closing
 
-      garageDoor.setDoorState(device.id, 1, function(err, device) {
+### garageDoor.setDoorState(id, state, callback, fastP)
+
+Set the requested door to open or close. 
+If the fastP parameter is not present, then returns an updated state once complete;
+otherwise returns immediately.
+
+      garageDoor.setDoorState(device.id, openP, function(err, device) {
         if(err) throw err;
         console.log(device);
       });


### PR DESCRIPTION
i have reviewed the other packages by:
- @adamheinmiller - https://github.com/adamheinmiller/ST_MyQ
- @pfeffed - https://github.com/pfeffed/liftmaster_myq

and then updated this package to reflect a “best hits” approach.

the changes:
1 headers: send User-Agent using brand from login response
2. parameters: use latest appId: and always send filterOn:
3. responses: look at both body.Message and body.ErrorMessage for error
messages
4. make sure logged in before attempting to retrieve devices, et. al.
5. keep track of longevity of security token, refreshing as needed
6. use latest paths (all lower-case, slightly different paths)
7. and the big one:

the return value on getDevices is flattened tree structure. first,
identify locations that are associated with gateways; then, identify
subordinate devices that are associated with garage doors.

note that in some cases “bogus” devices are returned (probably due to
incomplete registrations). in order to cull these, the
deviceRecord.response attribute, if present, is consulted to see if a
device is actually extant.
